### PR TITLE
Fix normalization

### DIFF
--- a/graph-parser_c/src/brandes.c
+++ b/graph-parser_c/src/brandes.c
@@ -43,6 +43,8 @@ static inline double round_decimal(double d){
 
 const int INFINITY_DIST = INT_MAX;
 
+double scale=1;
+
 /**
  * This function implements brandes algorithm. Given a weighted graph,
  * it returns an array of value, in which for every node identifier there is
@@ -63,7 +65,8 @@ const int INFINITY_DIST = INT_MAX;
  */
 double * betweeness_brandes(struct graph *g,
                             bool         endpoints,
-                            int *        articulation_point_val)
+                            int *        articulation_point_val,
+                            bool         normalized)
 {
     struct priority_queue q;
 
@@ -288,10 +291,18 @@ double * betweeness_brandes(struct graph *g,
     free(sigma);
     free(delta);
     struct node_list *nl = g -> nodes.head;
-    if ((node_num > 2) && (articulation_point_val == 0))
-    {    
-        double scale = 1 / (((double) (node_num - 1)) * ((double) (node_num - 2)));
 
+    if((normalized==true)&&(endpoints==true))
+        scale = 1 / (((double) (node_num - 1)) * ((double) (node_num - 2)));
+
+    else if((normalized==true)&&(endpoints==false))
+        scale = 1 / (((double) (node_num)) * ((double) (node_num - 1)));
+
+    else
+        scale = 0.5;
+
+    if ((node_num > 2) && (articulation_point_val == 0))
+    {
         for (i = 0; i < node_num; i++)
         {
             struct node_graph *ng = (struct node_graph*) nl -> content;
@@ -665,7 +676,7 @@ double * compute_traffic_matrix_and_centrality(
         }
     }
 
-    double * ret_val = betweeness_brandes(&(cc -> g), true, art_point_val);
+    double * ret_val = betweeness_brandes(&(cc -> g), true, art_point_val,false);
 
     free(art_point_val);
 
@@ -1184,13 +1195,13 @@ double * betwenness_heuristic(struct graph *g,
             free(connected_component_indexes);
             free(ret_val);
 
-            return betweeness_brandes(g, true, 0);
+            return betweeness_brandes(g, true, 0,false);
         }
     }
 
     if (node_num > 2)
     {
-        double scale = 1 / (((double) (node_num - 1)) * ((double) (node_num - 2)));
+        //double scale = 1 / (((double) (node_num - 1)) * ((double) (node_num - 2)));
 
         for (i = 0; i < node_num; i++)
         {
@@ -1223,4 +1234,3 @@ double * betwenness_heuristic(struct graph *g,
 
     return ret_val;
 }
-

--- a/graph-parser_c/src/brandes.h
+++ b/graph-parser_c/src/brandes.h
@@ -25,7 +25,8 @@ extern "C"
      */
     double * betweeness_brandes(struct graph *g,
                                 bool         endpoints,
-                                int *        articulation_point_val);
+                                int *        articulation_point_val,
+                                bool         normalized);
 
     /**
      * This is the algorithm described in the linked paper.
@@ -42,4 +43,3 @@ extern "C"
 #endif
 
 #endif /* ALGORITHMS_H */
-

--- a/graph-parser_c/src/graph_parser.c
+++ b/graph-parser_c/src/graph_parser.c
@@ -77,7 +77,7 @@ void graph_parser_calculate_bc(c_graph_parser * v)
     }
     else
     {
-        gp -> bc = betweeness_brandes(&(gp -> g), true, 0);
+        gp -> bc = betweeness_brandes(&(gp -> g),true, 0,false);
     }
 }
 
@@ -135,5 +135,3 @@ void delete_graph_parser(void * v)
 
     // gp->bc=0;
 }
-
-


### PR DESCRIPTION
Add parameter "normalized" to the function "betweeness_brandes".
The normalization now is:
if ((normalized==true)&&(endpoints==true)): 1 / ((n) * (n-1))
if ((normalized==true)&&(endpoints==false)): 1 / ((n-1)*(n-2)
if ((normalized==false): 0.5 

! In the code the first two normalization are inverted !